### PR TITLE
allow a fixture to match a url without considering the query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ In order to test newly added code you must rebuild the distribution.
 broccoli build dist
 ```
 
+### defineFixture
 Adding fixtures with `defineFixture` tells ic-ajax to resolve the promise
 with the fixture matching a url instead of making a request. This allows
 you to test your app without creating fake servers with sinon, etc.
@@ -96,6 +97,44 @@ ic.ajax.request('api/v1/courses').then(function(result) {
 ```
 
 To test failure paths, set the `textStatus` to anything but `success`.
+
+To set a fixture that will match every url with a matching path, regardless of the query string, add an options object as a parameter to `defineFixture` with a property of `fallback` set to true. A fixture will be located for the specific url with a query string, and if no fixture is found, the fallback that matches the path (not considering the query string) will be used.
+
+Example:
+
+```js
+ic.ajax.defineFixture('api/v1/courses', {
+  response: [{name: 'basket weaving'}],
+  jqXHR: {},
+  textStatus: 'success'
+}, {
+  fallback: true
+});
+
+ic.ajax.request('api/v1/courses?this=that').then(function(result) {
+  deepEqual(result, ic.ajax.lookupFixture('api/v1/courses').response);
+});
+```
+
+### lookupFixture
+Lookup a fixture. If successful, the fixture will be returned, otherwise `undefined` will be returned.
+
+```js
+var coursesFixture = ic.ajax.lookupFixture('api/v1/courses');
+```
+
+### removeFixture
+Remove a specific fixture. Pass in the url, the fixture that matches that url, if any, will be removed.
+
+```js
+ic.ajax.removeFixture('api/v1/courses');
+```
+
+### removeAllFixtures
+
+```js
+ic.ajax.removeAllFixtures();
+```
 
 
 Contributing

--- a/dist/cjs/main.js
+++ b/dist/cjs/main.js
@@ -33,7 +33,8 @@ function raw() {
 }
 
 exports.raw = raw;var __fixtures__ = {};
-exports.__fixtures__ = __fixtures__;
+exports.__fixtures__ = __fixtures__;var __fallbackFixtures__ = {};
+exports.__fallbackFixtures__ = __fallbackFixtures__;
 /*
  * Defines a fixture that will be used instead of an actual ajax
  * request to a given url. This is useful for testing, allowing you to
@@ -46,17 +47,25 @@ exports.__fixtures__ = __fixtures__;
  *      response: { firstName: 'Ryan', lastName: 'Florence' },
  *      textStatus: 'success'
  *      jqXHR: {}
+ *    }, {
+ *      fallback: true
  *    });
  *
  * @param {String} url
  * @param {Object} fixture
+ * @param {Object} [options] - options for the fixture
+ * @param {boolean} [options.fallback=false] - whether or not the fixture should be used for all routes with a matching path that do not have a fixture matching their query string
  */
 
-function defineFixture(url, fixture) {
+function defineFixture(url, fixture, options) {
   if (fixture.response) {
     fixture.response = JSON.parse(JSON.stringify(fixture.response));
   }
   __fixtures__[url] = fixture;
+
+  if (options && options.fallback) {
+    __fallbackFixtures__[url] = fixture;
+  }
 }
 
 exports.defineFixture = defineFixture;/*
@@ -66,14 +75,38 @@ exports.defineFixture = defineFixture;/*
  */
 
 function lookupFixture (url) {
-  return __fixtures__ && __fixtures__[url];
+  var fixture = __fixtures__ && __fixtures__[url];
+
+  if (!fixture && typeof url === "string" && url.match(/\?/)) {
+    fixture = __fallbackFixtures__ && __fallbackFixtures__[url.split("?")[0]];
+  }
+
+  return fixture;
 }
 
-exports.lookupFixture = lookupFixture;function makePromise(settings) {
+exports.lookupFixture = lookupFixture;/*
+ * Removes a fixture by url.
+ *
+ * @param {String} url
+ */
+function removeFixture (url) {
+  delete __fixtures__[url];
+  delete __fallbackFixtures__[url];
+}
+
+exports.removeFixture = removeFixture;/*
+ * Removes all fixtures.
+ */
+function removeAllFixtures () {
+  __fixtures__ = {};
+  __fallbackFixtures__ = {};
+}
+
+exports.removeAllFixtures = removeAllFixtures;function makePromise(settings) {
   return new Ember.RSVP.Promise(function(resolve, reject) {
     var fixture = lookupFixture(settings.url);
     if (fixture) {
-      if (fixture.onSend) {
+      if (fixture.onSend && typeof fixture.onSend === "function") {
         fixture.onSend(settings);
       }
       if (fixture.textStatus === 'success' || fixture.textStatus == null) {

--- a/dist/named-amd/main.js
+++ b/dist/named-amd/main.js
@@ -36,7 +36,8 @@ define("ic-ajax",
     }
 
     __exports__.raw = raw;var __fixtures__ = {};
-    __exports__.__fixtures__ = __fixtures__;
+    __exports__.__fixtures__ = __fixtures__;var __fallbackFixtures__ = {};
+    __exports__.__fallbackFixtures__ = __fallbackFixtures__;
     /*
      * Defines a fixture that will be used instead of an actual ajax
      * request to a given url. This is useful for testing, allowing you to
@@ -49,17 +50,25 @@ define("ic-ajax",
      *      response: { firstName: 'Ryan', lastName: 'Florence' },
      *      textStatus: 'success'
      *      jqXHR: {}
+     *    }, {
+     *      fallback: true
      *    });
      *
      * @param {String} url
      * @param {Object} fixture
+     * @param {Object} [options] - options for the fixture
+     * @param {boolean} [options.fallback=false] - whether or not the fixture should be used for all routes with a matching path that do not have a fixture matching their query string
      */
 
-    function defineFixture(url, fixture) {
+    function defineFixture(url, fixture, options) {
       if (fixture.response) {
         fixture.response = JSON.parse(JSON.stringify(fixture.response));
       }
       __fixtures__[url] = fixture;
+
+      if (options && options.fallback) {
+        __fallbackFixtures__[url] = fixture;
+      }
     }
 
     __exports__.defineFixture = defineFixture;/*
@@ -69,14 +78,38 @@ define("ic-ajax",
      */
 
     function lookupFixture (url) {
-      return __fixtures__ && __fixtures__[url];
+      var fixture = __fixtures__ && __fixtures__[url];
+
+      if (!fixture && typeof url === "string" && url.match(/\?/)) {
+        fixture = __fallbackFixtures__ && __fallbackFixtures__[url.split("?")[0]];
+      }
+
+      return fixture;
     }
 
-    __exports__.lookupFixture = lookupFixture;function makePromise(settings) {
+    __exports__.lookupFixture = lookupFixture;/*
+     * Removes a fixture by url.
+     *
+     * @param {String} url
+     */
+    function removeFixture (url) {
+      delete __fixtures__[url];
+      delete __fallbackFixtures__[url];
+    }
+
+    __exports__.removeFixture = removeFixture;/*
+     * Removes all fixtures.
+     */
+    function removeAllFixtures () {
+      __fixtures__ = {};
+      __fallbackFixtures__ = {};
+    }
+
+    __exports__.removeAllFixtures = removeAllFixtures;function makePromise(settings) {
       return new Ember.RSVP.Promise(function(resolve, reject) {
         var fixture = lookupFixture(settings.url);
         if (fixture) {
-          if (fixture.onSend) {
+          if (fixture.onSend && typeof fixture.onSend === "function") {
             fixture.onSend(settings);
           }
           if (fixture.textStatus === 'success' || fixture.textStatus == null) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -65,14 +65,20 @@ export function defineFixture(url, fixture) {
  */
 
 export function lookupFixture (url) {
-  return __fixtures__ && __fixtures__[url];
+  var fixture = __fixtures__ && __fixtures__[url];
+
+  if (!fixture && typeof url === "string" && url.match(/\?/)) {
+    fixture = __fixtures__ && __fixtures__[url.split("?")[0]];
+  }
+
+  return fixture;
 }
 
 function makePromise(settings) {
   return new Ember.RSVP.Promise(function(resolve, reject) {
     var fixture = lookupFixture(settings.url);
     if (fixture) {
-      if (fixture.onSend) {
+      if (fixture.onSend && typeof fixture.onSend === "function") {
         fixture.onSend(settings);
       }
       if (fixture.textStatus === 'success' || fixture.textStatus == null) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -32,6 +32,7 @@ export function raw() {
 }
 
 export var __fixtures__ = {};
+export var __fallbackFixtures__ = {};
 
 /*
  * Defines a fixture that will be used instead of an actual ajax
@@ -45,17 +46,25 @@ export var __fixtures__ = {};
  *      response: { firstName: 'Ryan', lastName: 'Florence' },
  *      textStatus: 'success'
  *      jqXHR: {}
+ *    }, {
+ *      fallback: true
  *    });
  *
  * @param {String} url
  * @param {Object} fixture
+ * @param {Object} [options] - options for the fixture
+ * @param {boolean} [options.fallback=false] - whether or not the fixture should be used for all routes with a matching path that do not have a fixture matching their query string
  */
 
-export function defineFixture(url, fixture) {
+export function defineFixture(url, fixture, options) {
   if (fixture.response) {
     fixture.response = JSON.parse(JSON.stringify(fixture.response));
   }
   __fixtures__[url] = fixture;
+
+  if (options && options.fallback) {
+    __fallbackFixtures__[url] = fixture;
+  }
 }
 
 /*
@@ -68,7 +77,7 @@ export function lookupFixture (url) {
   var fixture = __fixtures__ && __fixtures__[url];
 
   if (!fixture && typeof url === "string" && url.match(/\?/)) {
-    fixture = __fixtures__ && __fixtures__[url.split("?")[0]];
+    fixture = __fallbackFixtures__ && __fallbackFixtures__[url.split("?")[0]];
   }
 
   return fixture;

--- a/lib/main.js
+++ b/lib/main.js
@@ -83,6 +83,24 @@ export function lookupFixture (url) {
   return fixture;
 }
 
+/*
+ * Removes a fixture by url.
+ *
+ * @param {String} url
+ */
+export function removeFixture (url) {
+  delete __fixtures__[url];
+  delete __fallbackFixtures__[url];
+}
+
+/*
+ * Removes all fixtures.
+ */
+export function removeAllFixtures () {
+  __fixtures__ = {};
+  __fallbackFixtures__ = {};
+}
+
 function makePromise(settings) {
   return new Ember.RSVP.Promise(function(resolve, reject) {
     var fixture = lookupFixture(settings.url);


### PR DESCRIPTION
A fixture with a specific match to the query string will be matched first, if not found a fixture with the same path and no query string can be matched.